### PR TITLE
Remove --nofork, invalid betterlockscreen option.

### DIFF
--- a/airootfs/etc/skel/.config/i3/config
+++ b/airootfs/etc/skel/.config/i3/config
@@ -80,7 +80,7 @@ bindsym $mod+x exec betterlockscreen -l
 
 # The 4 lines of text above come from i3 documentation. Waking up from a suspended
 # system will launch betterlockscreen
-exec --no-startup-id xss-lock --transfer-sleep-lock -- betterlockscreen -l --nofork
+exec --no-startup-id xss-lock --transfer-sleep-lock -- betterlockscreen -l
 
 # NetworkManager is the most popular way to manage wireless networks on Linux,
 # and nm-applet is a desktop environment-independent system tray GUI for it.


### PR DESCRIPTION
--nofork is an i3lock option.  When xss-lock receives lock notifications, betterlockscreen will display help text, instead of locking screen.

Steps to replicate:
Open 2 terminals.
In first terminal:  killall xss-lock && xss-lock --transfer-sleep-lock -- betterlockscreen -l --nofork
In second terminal:  loginctl lock-session
Remove --nofork and observe the screen locking correctly.

TY